### PR TITLE
Improve readability

### DIFF
--- a/include/cc_net_conn.h
+++ b/include/cc_net_conn.h
@@ -40,11 +40,31 @@ typedef enum addr_type_ {
     IPV6
 } addr_type_e;
 
+typedef enum cc_ofrw_state_ {
+    CC_OF_RW_DOWN = 0,
+    CC_OF_RW_UP
+} cc_ofrw_state_e;
+
 typedef struct cc_ofdev_key_ {
     ipaddr_v4v6_t  controller_ip_addr;
     ipaddr_v4v6_t  switch_ip_addr; 
     uint16_t       controller_L4_port;
 } cc_ofdev_key_t;
+
+/* node in ofdev_htbl */
+typedef struct cc_ofdev_info_ {
+    cc_ofver_e     of_max_ver;  /* cc_ofver_e */
+    
+    GList          *ofrw_socket_list; //list of rw sockets
+
+    cc_of_recv_pkt recv_func; /* cc_of_recv_pkt function ptr */
+    cc_of_accept_channel accept_chann_func; /* cc_of_accept_channel func ptr */
+    cc_of_delete_channel del_chann_func;/* cc_of_delete_channel function ptr */
+
+    int            main_sockfd_tcp;
+    int            main_sockfd_udp;
+} cc_ofdev_info_t;
+
 
 /* mapping of channel key (dp-id/aux-id) to rw_sockfd) */
 typedef struct cc_ofchannel_key_ {
@@ -63,25 +83,6 @@ typedef struct cc_ofchannel_info_ {
     int                   count_retries; /* CLIENT: reconnection attempts */
     cc_ofstats_t          stats;    
 } cc_ofchannel_info_t;
-
-/* node in ofdev_htbl */
-typedef struct cc_ofdev_info_ {
-    cc_ofver_e     of_max_ver;  /* cc_ofver_e */
-    
-    GList          *ofrw_socket_list; //list of rw sockets
-
-    cc_of_recv_pkt recv_func; /* cc_of_recv_pkt function ptr */
-    cc_of_accept_channel accept_chann_func; /* cc_of_accept_channel func ptr */
-    cc_of_delete_channel del_chann_func;/* cc_of_delete_channel function ptr */
-
-    int            main_sockfd_tcp;
-    int            main_sockfd_udp;
-} cc_ofdev_info_t;
-
-typedef enum cc_ofrw_state_ {
-    CC_OF_RW_DOWN = 0,
-    CC_OF_RW_UP
-} cc_ofrw_state_e;
 
 typedef struct cc_ofrw_key_ {
     int       rw_sockfd;    

--- a/include/cc_of_util.h
+++ b/include/cc_of_util.h
@@ -48,6 +48,9 @@ typedef enum htbl_type_ {
     OFCHANN
 } htbl_type_e;
 
+/********************************************************************/
+/* Hash Table Manipulation Functions */
+/********************************************************************/
 guint cc_ofdev_hash_func(gconstpointer key);
 
 guint cc_ofchann_hash_func(gconstpointer key);
@@ -67,20 +70,9 @@ gboolean cc_ofchannel_htbl_equal_func(gconstpointer a,
 gboolean cc_ofrw_htbl_equal_func(gconstpointer a, 
                                  gconstpointer b);
 
-cc_of_ret
-update_global_htbl(htbl_type_e htbl_type,
-                   htbl_update_ops_e htbl_op,
-                   gpointer htbl_key,
-                   gpointer htbl_data,
-                   gboolean *new_entry);
-
-cc_of_ret
-update_global_htbl_lockfree(htbl_type_e htbl_type,
-                            htbl_update_ops_e htbl_op,
-                            gpointer htbl_key,
-                            gpointer htbl_data,
-                            gboolean *new_entry);
-
+/********************************************************************/
+/* Global Hash Table Print Functions */
+/********************************************************************/
 void
 print_ofdev_htbl(void);
 void
@@ -89,52 +81,54 @@ void
 print_ofchann_htbl(void);
 
 
+/********************************************************************/
+/* Global Hash Table Access Functions */
+/********************************************************************/
+cc_of_ret
+update_global_htbl_lockfree(htbl_type_e htbl_type,
+                            htbl_update_ops_e htbl_op,
+                            gpointer htbl_key,
+                            gpointer htbl_data,
+                            gboolean *new_entry);
 
-void
-print_ofrw_htbl(void);
-
-void
-print_ofchann_htbl(void);
-
-
-
+/* static functions
 cc_of_ret
 del_ofrw_rwsocket(int del_fd);
 
 cc_of_ret
 add_upd_ofrw_ofdev_rwsocket(int add_fd);
 
+static cc_of_ret
+add_ofdev_rwsocket_lockfree(cc_ofdev_key_t key, int rwsock);
+
 cc_of_ret
-find_thrmgr_rwsocket(int sockfd,  
-                     adpoll_thread_mgr_t **tmgr);
+del_ofdev_rwsocket_lockfree(cc_ofdev_key_t key, int rwsock);
+
+cc_of_ret
+add_upd_ofchann_rwsocket_lockfree(cc_ofchannel_key_t key, int rwsock);
+*/
+cc_of_ret
+del_ofchann_rwsocket_lockfree(int rwsock);
+
+cc_of_ret
+find_ofchann_key_rwsocket_lockfree(int sockfd, 
+                                   cc_ofchannel_key_t **fd_chann_key);
+
+cc_of_ret
+find_thrmgr_rwsocket_safe(int sockfd,  
+                          adpoll_thread_mgr_t **tmgr);
 
 cc_of_ret
 find_thrmgr_rwsocket_lockfree(int sockfd,  
                      adpoll_thread_mgr_t **tmgr);
 
 cc_of_ret
-add_upd_ofchann_rwsocket(cc_ofchannel_key_t key,
-                         int rwsock);
-
-cc_of_ret
-del_ofchann_rwsocket(int rwsock);
-
-cc_of_ret
-find_ofchann_key_rwsocket(int sockfd, 
-                          cc_ofchannel_key_t **fd_chann_key);
-
-cc_of_ret
-add_ofdev_rwsocket(cc_ofdev_key_t key, int rwsock);
-
-cc_of_ret
-del_ofdev_rwsocket(cc_ofdev_key_t key, int rwsock);
-
-cc_of_ret
-atomic_add_upd_htbls_with_rwsocket(int sockfd, struct sockaddr_in *client_addr, 
-                                   adpoll_thread_mgr_t  *thr_mgr,
-                                   cc_ofdev_key_t key,
-                                   L4_type_e layer4_proto, 
-                                   cc_ofchannel_key_t ofchann_key);
+atomic_add_upd_htbls_with_rwsocket_lockfree(
+    int sockfd, struct sockaddr_in *client_addr, 
+    adpoll_thread_mgr_t  *thr_mgr,
+    cc_ofdev_key_t key,
+    L4_type_e layer4_proto, 
+    cc_ofchannel_key_t ofchann_key);
 
 /*-----------------------------------------------------------------------*/
 /* POLLTHR utilities                                                     */
@@ -144,25 +138,26 @@ atomic_add_upd_htbls_with_rwsocket(int sockfd, struct sockaddr_in *client_addr,
 /*-----------------------------------------------------------------------*/
 
 cc_of_ret
-cc_create_rw_pollthr(adpoll_thread_mgr_t **tmgr);
+cc_create_rw_pollthr_safe(adpoll_thread_mgr_t **tmgr);
 
 guint
-cc_get_count_rw_pollthr(void);
+cc_get_count_rw_pollthr_safe(void);
 
 
 cc_of_ret
-cc_find_or_create_rw_pollthr(adpoll_thread_mgr_t **tmgr);
+cc_find_or_create_rw_pollthr_safe(adpoll_thread_mgr_t **tmgr);
 
 
 cc_of_ret
-cc_del_sockfd_rw_pollthr(adpoll_thread_mgr_t *tmgr, 
-                         adpoll_thr_msg_t *msg);
+cc_del_sockfd_rw_pollthr_lockfree(adpoll_thread_mgr_t *tmgr, 
+                                  adpoll_thr_msg_t *msg);
 
 
+/* This function ACQUIRES LOCKS */
 cc_of_ret
-cc_add_sockfd_rw_pollthr(adpoll_thr_msg_t *msg, 
-                         cc_ofdev_key_t key, 
-                         L4_type_e layer4_proto,
-                         cc_ofchannel_key_t ofchann_key);
+cc_add_sockfd_rw_pollthr_safe(adpoll_thr_msg_t *msg, 
+                              cc_ofdev_key_t key, 
+                              L4_type_e layer4_proto,
+                              cc_ofchannel_key_t ofchann_key);
 
 #endif //CC_OF_UTIL_H

--- a/include/cc_pollthr_mgr.h
+++ b/include/cc_pollthr_mgr.h
@@ -75,7 +75,9 @@
 #define UNUSED __attribute__ ((__unused__))
 #endif
 
-/* Thread-private data for Polling Thread */
+/* Holds thread-private data for Polling Thread
+   The data itself is defined by struct pollthr_private_t
+ */
 GPrivate tname_key;
 
 typedef enum adpoll_fd_type_ {
@@ -209,7 +211,7 @@ uint32_t adp_thr_mgr_get_num_avail_sockfd(adpoll_thread_mgr_t *this);
 void adp_thr_mgr_free(adpoll_thread_mgr_t *this);
 
 /********************************************************************/
-/* ADPOLL-THREAD PRIVATE */
+/* ADPOLL-THREAD INTERNAL DECLARATIONS */
 /********************************************************************/
 /* parameter for starting new thread manager */
 typedef struct adpoll_pollthr_data_ {

--- a/src/cc_of_lib.c
+++ b/src/cc_of_lib.c
@@ -122,7 +122,7 @@ cc_of_lib_init(of_dev_type_e dev_type)
     cc_of_global.ofrw_pollthr_list = NULL;
     g_mutex_init(&cc_of_global.ofrw_pollthr_list_lock);
     adpoll_thread_mgr_t *tmgr = NULL;
-    if ((status = cc_create_rw_pollthr(&tmgr)) < 0) {
+    if ((status = cc_create_rw_pollthr_safe(&tmgr)) < 0) {
 	    cc_of_lib_free();
 	    CC_LOG_FATAL("%s(%d): %s", __FUNCTION__, __LINE__, 
                      cc_of_strerror(status));
@@ -837,7 +837,7 @@ cc_of_send_pkt(uint64_t dp_id, uint8_t aux_id, void *of_msg,
     chann_info = (cc_ofchannel_info_t *)chht_info;
     send_rwsock = chann_info->rw_sockfd;
 
-    find_thrmgr_rwsocket(send_rwsock, &tmgr);
+    find_thrmgr_rwsocket_safe(send_rwsock, &tmgr);
 
     if (tmgr == NULL) {
         CC_LOG_ERROR("%s(%d): socket %d is invalid",
@@ -900,7 +900,7 @@ cc_of_set_real_dpid_auxid(uint64_t dummy_dpid, uint8_t dummy_auxid,
 
 
     memcpy(&ofchann_info_new, ofchann_info_old, sizeof(cc_ofchannel_info_t));
-    status = del_ofchann_rwsocket((int)dummy_dpid);
+    status = del_ofchann_rwsocket_lockfree((int)dummy_dpid);
 	print_ofchann_htbl();
     update_global_htbl_lockfree(OFCHANN, ADD, (gpointer)&ofchann_key_new, 
                        &ofchann_info_new, &new_entry); 

--- a/src/cc_pollthr_mgr.c
+++ b/src/cc_pollthr_mgr.c
@@ -369,6 +369,19 @@ fd_entry_free(adpoll_fd_info_t *data)
     free(data);
 }
 
+/* Function: poll_fd_process
+
+   This function is called by the polling loop in
+   adp_thr_mgr_poll_thread_func when poll() returns
+   a valid event.
+   
+   poll_fd_process iterates through the entire fd_list
+   and processes the specific event on the correct fd.
+
+   POLLIN: call the registered callback for processing
+   POLLOUT: retrieve the relevant data from hash table
+   and send out on fd
+*/
 static void
 poll_fd_process(adpoll_fd_info_t *data_p,
                 char *tname)

--- a/tests/util_test.c
+++ b/tests/util_test.c
@@ -136,7 +136,7 @@ util_start(test_data_t *tdata,
 
    
     cc_of_log_clear();
-    cc_create_rw_pollthr(&temp_mgr_p);
+    cc_create_rw_pollthr_safe(&temp_mgr_p);
     g_assert(temp_mgr_p != NULL);
     
     g_memmove(&tdata->tp_data[0], temp_mgr_p, sizeof(adpoll_thread_mgr_t));
@@ -487,7 +487,7 @@ util_tc_2(test_data_t *tdata UNUSED, gconstpointer tudata)
     thr_msg.pollin_func = &process_tcpfd_pollin_func;
     thr_msg.pollout_func = &process_tcpfd_pollout_func;
     
-    client_status = cc_add_sockfd_rw_pollthr(&thr_msg, devkey, TCP, ofchann_key);
+    client_status = cc_add_sockfd_rw_pollthr_safe(&thr_msg, devkey, TCP, ofchann_key);
     if (client_status < 0) {
         CC_LOG_ERROR("%s(%d):Error updating tcp sockfd in global structures: %s",
                      __FUNCTION__, __LINE__, cc_of_strerror(errno));


### PR DESCRIPTION
Added lots of documentation - function headers, file headers 
Renamed many functions to indicate whether safe or lockfree.
Re-arranged header files for better maintainability and readability

Unit tests pass.

Unit test report:
TEST: /home/libccof/deepa-git/OFconnect/tests/pollthr_test.exe... (pid=22879)
  /pollthread/tc_1:                                                    OK
  /pollthread/tc_2:                                                    OK
  /pollthread/tc_3:                                                    OK
  /pollthread/tc_4:                                                    OK
  /pollthread/tc_5:                                                    OK
PASS: /home/libccof/deepa-git/OFconnect/tests/pollthr_test.exe
gcc /home/libccof/deepa-git/OFconnect/obj/cc_log.o /home/libccof/deepa-git/OFconnect/obj/cc_of_lib.o /home/libccof/deepa-git/OFconnect/obj/cc_of_util.o /home/libccof/deepa-git/OFconnect/obj/cc_pollthr_mgr.o /home/libccof/deepa-git/OFconnect/obj/cc_tcp_conn.o /home/libccof/deepa-git/OFconnect/obj/cc_udp_conn.o /home/libccof/deepa-git/OFconnect/tests/util_test.o -o /home/libccof/deepa-git/OFconnect/tests/util_test.exe -lglib-2.0
gtester
gtester --verbose -o=/home/libccof/deepa-git/OFconnect/tests/log-util_test.xml -k /home/libccof/deepa-git/OFconnect/tests/util_test.exe
TEST: /home/libccof/deepa-git/OFconnect/tests/util_test.exe... (pid=22910)
  /util/tc_1:                                                          OK
  /util/tc_2:                                                          OK
PASS: /home/libccof/deepa-git/OFconnect/tests/util_test.exe
gtester
sed "|</gtester>| i \
      <info>\
        <package>TEST PACKAGE</package>\
        <version>0</version>\
        <revision>1</revision>\
      </info>\
    " --in-place='' /home/libccof/deepa-git/OFconnect/tests/log-pollthr_test.xml
gtester-report /home/libccof/deepa-git/OFconnect/tests/log-pollthr_test.xml > /home/libccof/deepa-git/OFconnect/tests/log-pollthr_test.html
gtester
sed "|</gtester>| i \
      <info>\
        <package>TEST PACKAGE</package>\
        <version>0</version>\
        <revision>1</revision>\
      </info>\
    " --in-place='' /home/libccof/deepa-git/OFconnect/tests/log-util_test.xml
gtester-report /home/libccof/deepa-git/OFconnect/tests/log-util_test.xml > /home/libccof/deepa-git/OFconnect/tests/log-util_test.html
